### PR TITLE
Fix for Issue #12.

### DIFF
--- a/roles/director/tasks/main.yml
+++ b/roles/director/tasks/main.yml
@@ -139,6 +139,7 @@
   shell: |
     set -o pipefail
     openstack subnet list | grep ctlplane-subnet | awk '{print $2}' | xargs
+  environment: "{{ osp_director_os_env_data }}"
   register: _osp_director_read_subnet_info
 
 - name: Setting a nameserver for the control plane


### PR DESCRIPTION
Adding the key value that sets the environment for the openstack cli command to reference for the task 'Read subnet info'.

Without this is place we were seeing a msg 'missing value auth-url'